### PR TITLE
[Client] / #Fix / Fix: 챌린지 확인 후 뒤로 가기

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -32,9 +32,11 @@ function App() {
           <Route path='/confirmchallenge' element={<ConfirmChallenge />} />
           <Route path='/mypage/:id' element={<Mypage />} />
           <Route path='/editmyinfo' element={<EditMyinfo />} />
-          <Route path='/oauth/callback/kakao' element={<KakaoPage />} />
-          <Route path='/oauth/callback/naver' element={<NaverPage />} />
-          <Route path='/oauth/callback/google' element={<GooglePage />} />
+          <Route path='/oauth/callback'>
+            <Route path='kakao' element={<KakaoPage />} />
+            <Route path='naver' element={<NaverPage />} />
+            <Route path='google' element={<GooglePage />} />
+          </Route>
           <Route path='*' element={<NotFound />} />
         </Routes>
       </main>

--- a/client/src/pages/ConfirmChallenge.js
+++ b/client/src/pages/ConfirmChallenge.js
@@ -155,14 +155,14 @@ const ConfirmChallenge = () => {
         return (
           <>
             <p>챌린지가 생성되었습니다.</p>
-            <Button content='확인' handler={() => navigate(`/challenge/${responseData.data.challenge_id}`)} />
+            <Button content='확인' handler={() => navigate(`/challenge/${responseData.data.challenge_id}`, { replace: true })} />
           </>
         );
       case 'success edit challenge':
         return (
           <>
             <p>챌린지가 수정되었습니다.</p>
-            <Button content='확인' handler={() => navigate(`/challenge/${responseData.data.challenge_id}`)} />
+            <Button content='확인' handler={() => navigate(`/challenge/${responseData.data.challenge_id}`, { replace: true })} />
           </>
         );
       case 'wait response':


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

반영 브랜치
fix/navigateReplace -> dev

변경 사항
1. 챌린지 확인 후 뒤로 갈 때, 확인 페이지 보이지 않게 함
2. 소셜로그인 페이지 nasted routing